### PR TITLE
feat: add list of tags showing with each blog post title

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -37,6 +37,20 @@ export default function BlogPosts() {
                   {formatDate(post.metadata.publishedAt, false)}
                 </p>
               </div>
+
+              {/* Add tags display */}
+              {post.metadata.tags && (
+                <div className="flex flex-wrap gap-2 mt-1">
+                  {post.metadata.tags.split(",").map((tag, index) => (
+                    <span 
+                      key={index} 
+                      className="px-2 py-1 text-xs bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 font-mono"
+                    >
+                      {tag.trim()}
+                    </span>
+                  ))}
+                </div>
+              )}
             </Link>
           ))}
       </div>


### PR DESCRIPTION
Hi! The blog posts have tags in them, but those don't seem to be displayed anywhere

This change adds labels showing the tags of each blog post in the blog posts page:

![image](https://github.com/user-attachments/assets/f03a4815-7fc6-4315-bcbd-3974f7a71439)